### PR TITLE
Add Turkish translation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(RES_FILES
 set(TRANSLATION_FILES
     translations/it_IT.ts
     translations/cs_CZ.ts
+    translations/tr_TR.ts
     translations/zh_CN.ts
     translations/zh_TW.ts
 )

--- a/src/src.pro
+++ b/src/src.pro
@@ -55,6 +55,7 @@ RESOURCES += finalhe.qrc
 TRANSLATIONS += \
     translations/it_IT.ts \
     translations/cs_CZ.ts \
+    translations/tr_TR.ts \
     translations/zh_CN.ts \
     translations/zh_TW.ts
 

--- a/src/translations/tr_TR.ts
+++ b/src/translations/tr_TR.ts
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="zh_TW">
+<context>
+    <name>FinalHE</name>
+    <message>
+        <location filename="../main.cc" line="74"/>
+        <source>WARNING</source>
+        <translation>DİKKAT</translation>
+    </message>
+    <message>
+        <location filename="../main.cc" line="74"/>
+        <source>Qcma is running, force close it now?</source>
+        <translation>Qcma arkaplanda çalışıyor, zorla kapatılsın mı?</translation>
+    </message>
+    <message>
+        <location filename="../main.cc" line="78"/>
+        <source>Unable to close Qcma, please close it manually and then restart this tool.</source>
+        <translation>Qcma kapatılamadı, lütfen elle kapatın ve bu programı yeniden başlatın.</translation>
+    </message>
+    <message>
+        <location filename="../main.cc" line="78"/>
+        <source>ERROR</source>
+        <translation>HATA</translation>
+    </message>
+    <message>
+        <source>You don&apos;t have write permission to this folder! Exit now.</source>
+        <translation type="unfinished">Bu klasöre yazma izniniz yok! Başka bir klasör seçin.</translation>
+    </message>
+    <message>
+        <location filename="../finalhe.cc" line="119"/>
+        <source>Registering device: %1
+Input this PIN on PS Vita: %2</source>
+        <translation>Cihaz kaydediliyor: %1
+Bu PIN&apos;i PS Vita cihazınızda girin: %2</translation>
+    </message>
+    <message>
+        <location filename="../finalhe.cc" line="123"/>
+        <source>Registered device.</source>
+        <translation>Kayıtlı cihaz.</translation>
+    </message>
+</context>
+<context>
+    <name>FinalHEClass</name>
+    <message>
+        <location filename="../finalhe.ui" line="125"/>
+        <source> Let&apos;s GO! </source>
+        <translation>BAŞLA</translation>
+    </message>
+    <message>
+        <location filename="../finalhe.ui" line="144"/>
+        <source>Trim h-encore to ~13MB</source>
+        <translation>Gereksiz dosyaları silerek h-encore boyutunu ~13MB&apos;ye düşür
+        </translation>
+    </message>
+</context>
+<context>
+    <name>Package</name>
+    <message>
+        <location filename="../package.cc" line="96"/>
+        <source>Downloading %1</source>
+        <translation>%1 indiriliyor</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="117"/>
+        <source>Unpacking %1</source>
+        <translation>%1 arşivden çıkarılıyor</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="131"/>
+        <source>Failed to unpack %1</source>
+        <translation>%1 arşivden çıkarılamadı</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="153"/>
+        <source>Decompressing %1</source>
+        <translation>%1 decompress ediliyor</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="168"/>
+        <source>Failed to decompress %1</source>
+        <translation>%1 decompress edilemedi</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="207"/>
+        <source>Verifying %1</source>
+        <translation>%1 doğrulanıyor</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="252"/>
+        <source>Everything is ready, now follow below steps on your PS Vita:
+1. Launch Content Manager and connect to your computer.
+2. Select &quot;PC -&gt; PS Vita System&quot; -&gt; &quot;Applications&quot; -&gt; &quot;PS Vita&quot;.
+3. Transfer &quot;h-encore&quot; to your PS Vita.
+4. Run &quot;h-encore&quot; and... Yay, that&apos;s it!</source>
+        <translation>Her şey hazır, aşağıdaki anlatılanları PS Vita&apos;nızda yapın:
+1. İçerik Yöneticisi&apos;ni açın ve cihazı bilgisayarınıza bağlayın.
+2. Sırasıyla şu seçenekleri seçin: &quot;Bilgisayar -&gt; PS Vita Sistemi&quot; -&gt; &quot;Uygulamalar&quot; -&gt; &quot;PS Vita&quot;.
+3. &quot;h-encore&quot;&apos;u PS Vita&apos;nıza aktarın.
+4. PS Vita&apos;nızda &quot;h-encore&quot;&apos;u çalıştırın vee... İşte bu kadar!</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="246"/>
+        <source>Fetching backup key from cma.henkaku.xyz</source>
+        <translation type="unfinished">cma.henkaku.xyz adresinden yedek anahtarı alınıyor</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="350"/>
+        <source>Fetched backup key.
+Click button to START!</source>
+        <translation>Yedek anahtarı alındı.
+Başlamak için düğmeye basın.</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="290"/>
+        <source>Trimming package</source>
+        <translation>Paketten gereksiz dosyalar siliniyor.</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="40"/>
+        <source>Launch Content Manager on PS Vita and connect to computer.</source>
+        <translation>PS Vita&apos;nzıda İçerik Yöneticisi&apos;ni açın ve bilgisayara bağlayın.</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="320"/>
+        <source>Createing psvimg&apos;s</source>
+        <translation>psvimg oluşturuluyor.</translation>
+    </message>
+    <message>
+        <location filename="../package.cc" line="347"/>
+        <source>Cannot get backup key from your AID.
+Please check your network connection!</source>
+        <translation>AID&apos;iniz kullanılarak yedek anahtarı alınamadı.
+Lütfen internet bağlantınızı kontrol edin.</translation>
+    </message>
+</context>
+<context>
+    <name>VitaConn</name>
+    <message>
+        <location filename="../vita.cc" line="356"/>
+        <source>Waiting for connection to PS Vita...</source>
+        <translation>PS Vita&apos;ya bağlantı için bekleniyor.</translation>
+    </message>
+    <message>
+        <location filename="../vita.cc" line="359"/>
+        <source>Connected to PS Vita [%1], Waiting for account ID</source>
+        <translation>Bağlanılan PS Vita: [%1], hesap ID bekleniyor.</translation>
+    </message>
+    <message>
+        <location filename="../vita.cc" line="361"/>
+        <source>Connected to PS Vita [%1] (%2)</source>
+        <translation>Bağlanılan PS Vita: [%1] (%2)</translation>
+    </message>
+</context>
+<context>
+    <name>base</name>
+    <message>
+        <location filename="../finalhe.cc" line="37"/>
+        <location filename="../finalhe.cc" line="132"/>
+        <source>English</source>
+        <translation>Türkçe</translation>
+    </message>
+    <message>
+        <location filename="../finalhe.cc" line="45"/>
+        <source>LANGUAGE</source>
+        <translation>DİL</translation>
+    </message>
+</context>
+</TS>

--- a/src/translations/tr_TR.ts
+++ b/src/translations/tr_TR.ts
@@ -37,7 +37,7 @@ Bu PIN&apos;i PS Vita cihazınızda girin: %2</translation>
     <message>
         <location filename="../finalhe.cc" line="123"/>
         <source>Registered device.</source>
-        <translation>Kayıtlı cihaz.</translation>
+        <translation>Cihaz kaydedildi.</translation>
     </message>
 </context>
 <context>

--- a/src/translations/tr_TR.ts
+++ b/src/translations/tr_TR.ts
@@ -95,9 +95,10 @@ Bu PIN&apos;i PS Vita cihazınızda girin: %2</translation>
 4. Run &quot;h-encore&quot; and... Yay, that&apos;s it!</source>
         <translation>Her şey hazır, aşağıdaki anlatılanları PS Vita&apos;nızda yapın:
 1. İçerik Yöneticisi&apos;ni açın ve cihazı bilgisayarınıza bağlayın.
-2. Sırasıyla şu seçenekleri seçin: &quot;Bilgisayar -&gt; PS Vita Sistemi&quot; -&gt; &quot;Uygulamalar&quot; -&gt; &quot;PS Vita&quot;.
-3. &quot;h-encore&quot;&apos;u PS Vita&apos;nıza aktarın.
-4. PS Vita&apos;nızda &quot;h-encore&quot;&apos;u çalıştırın vee... İşte bu kadar!</translation>
+2. Sırasıyla şu seçenekleri seçin: 
+&quot;Bilgisayar&quot; - &quot;PS Vita Sistemi&quot; - &quot;Uygulamalar&quot; - &quot;PS Vita&quot;
+3. &quot;h-encore&quot;u PS Vita&apos;nıza aktarın.
+4. PS Vita&apos;nızda &quot;h-encore&quot;u çalıştırın vee... İşte bu kadar!</translation>
     </message>
     <message>
         <location filename="../package.cc" line="246"/>

--- a/src/translations/tr_TR.ts
+++ b/src/translations/tr_TR.ts
@@ -158,12 +158,12 @@ Lütfen internet bağlantınızı kontrol edin.</translation>
         <location filename="../finalhe.cc" line="37"/>
         <location filename="../finalhe.cc" line="132"/>
         <source>English</source>
-        <translation>Türkçe</translation>
+        <translation>İngilizce</translation>
     </message>
     <message>
         <location filename="../finalhe.cc" line="45"/>
         <source>LANGUAGE</source>
-        <translation>DİL</translation>
+        <translation>Türkçe</translation>
     </message>
 </context>
 </TS>

--- a/src/translations/tr_TR.ts
+++ b/src/translations/tr_TR.ts
@@ -119,7 +119,7 @@ Başlamak için düğmeye basın.</translation>
     <message>
         <location filename="../package.cc" line="40"/>
         <source>Launch Content Manager on PS Vita and connect to computer.</source>
-        <translation>PS Vita&apos;nzıda İçerik Yöneticisi&apos;ni açın ve bilgisayara bağlayın.</translation>
+        <translation>PS Vita&apos;nızda İçerik Yöneticisi&apos;ni açın ve bilgisayara bağlayın.</translation>
     </message>
     <message>
         <location filename="../package.cc" line="320"/>


### PR DESCRIPTION
Sorry, this pull request is a bit messy (4 commits) but I just kept finding some little errors just before publishing, and... You know how it is.

So here are the details:
"Let's GO!" sound very, VERY VERY VERY forced in Turkish. I used the equilevant of "START".
"trim" sound very technical and elitistic in Turkish so I used "remove unnecessary files from h-encore".
There is no word for "decompress" in Turkish (we use unpack for it) so I left it as is.
I had to create a new line in the "finish" text (4 step one) as it didn't fit with the translation. Really nothing big, but worth mentioning.
"Connected to PS Vita [%1] (%2)" sound much, MUCH better in Turkish as "PS Vita that is connected right now: [%1] (%2)" so I used that.

Also, I'm on Windows and I don't trust git on Windows, so can you try to compile the translation file and see if it came through OK?

Hope this translation is good enough.