### PR TITLE
updating to support 3.73 using existing h-encore2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+v1.92
+1. Added support for 3.73 with existing h-encore^2
+
 v1.91
 1. Added support for 3.72 with updated h-encore²
 

--- a/src/finalhe.cc
+++ b/src/finalhe.cc
@@ -258,7 +258,7 @@ void FinalHE::enableStart() {
             pkg->setCoreType(ECoreType::Memecore);
         else if (vita->getDeviceVersion() <= "3.68")
             pkg->setCoreType(ECoreType::HEncore);
-        else if (vita->getDeviceVersion() <= "3.72")
+        else if (vita->getDeviceVersion() <= "3.73")
             pkg->setCoreType(ECoreType::HEncore2);
         ui.textPkg->setText(tr("Click button to START!"));
         ui.btnStart->setEnabled(true);


### PR DESCRIPTION
Existing hencore2 works with 3.73, just need to update selection statement to be inclusive of 3.73 firmwares. 