### PR TITLE
Set a cmake policy if using cmake version 3.17 or greater

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(SET CMP0100 NEW)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+    cmake_policy(SET CMP0100 NEW)
+endif()
+
 project(finalhe C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-
+cmake_policy(SET CMP0100 NEW)
 project(finalhe C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")


### PR DESCRIPTION
When running `cmake .` using cmake version 3.17.0 or greater various header files would be excluded for compatibility.  
  
Example:  
```
tylerww@MacBookPro finalhe % cmake .
-- Configuring done
CMake Warning (dev) in src/CMakeLists.txt:
  Policy CMP0100 is not set: Let AUTOMOC and AUTOUIC process .hh files.  Run
  "cmake --help-policy CMP0100" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  For compatibility, CMake is excluding the header file(s):

    "/Users/tylerww/Desktop/vita/finalhe/src/downloader.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/finalhe.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/package.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/sforeader.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/vita.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/worker.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/worker.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/vita.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/sforeader.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/package.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/finalhe.hh"
    "/Users/tylerww/Desktop/vita/finalhe/src/downloader.hh"

  from processing by AUTOMOC.  If any of the files should be processed, set
  CMP0100 to NEW.  If any of the files should not be processed, explicitly
  exclude them by setting the source file property SKIP_AUTOMOC:

    set_property(SOURCE file.hh PROPERTY SKIP_AUTOMOC ON)

This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
-- Build files have been written to: /Users/tylerww/Desktop/vita/finalhe
```

Ignoring this warning and running `make` to build the project would produce the following error as a result:  
```
Undefined symbols for architecture x86_64:
  "Downloader::finishedGet(void*)", referenced from:
      Downloader::downloadFinished(QNetworkReply*) in downloader.cc.o
  "Downloader::finishedFile(QFile*)", referenced from:
      Downloader::downloadFinished(QNetworkReply*) in downloader.cc.o
  "Downloader::downloadProgress(unsigned long long, unsigned long long)", referenced from:
      Downloader::downloadProg(long long, long long) in downloader.cc.o
  "Worker::staticMetaObject", referenced from:
      std::__1::enable_if<(QtPrivate::FunctionPointer<Worker::start(QObject*, std::__1::function<void (void*)> const&, std::__1::function<void (void*)> const&, void*)::$_1>::ArgumentCount) == (-(1)), QMetaObject::Connection>::type QObject::connect<void (Worker::*)(), Worker::start(QObject*, std::__1::function<void (void*)> const&, std::__1::function<void (void*)> const&, void*)::$_1>(QtPrivate::FunctionPointer<void (Worker::*)()>::Object const*, void (Worker::*)(), QObject const*, Worker::start(QObject*, std::__1::function<void (void*)> const&, std::__1::function<void (void*)> const&, void*)::$_1, Qt::ConnectionType) in worker.cc.o
  "Worker::finished()", referenced from:
      Worker::start(QObject*, std::__1::function<void (void*)> const&, std::__1::function<void (void*)> const&, void*) in worker.cc.o
      Worker::start(QObject*, std::__1::function<void (void*)> const&, std::__1::function<void (void*)> const&, void*)::$_0::operator()() const in worker.cc.o
  "FinalHE::staticMetaObject", referenced from:
      FinalHE::tr(char const*, char const*, int) in finalhe.cc.o
  "Package::setPercent(int)", referenced from:
      _output_progress(void*, unsigned long long) in package.cc.o
      Package::verify(QString const&, char const*) in package.cc.o
      Package::finishBuildData() in package.cc.o
      Package::downloadProg(unsigned long long, unsigned long long) in package.cc.o
      Package::startUnpackDemo(char const*)::$_3::operator()(void*) const in package.cc.o
      Package::doUnpackZip()::$_4::operator()(void*) const in package.cc.o
      Package::createPsvImgs(QString)::$_9::operator()(void*) const in package.cc.o
      ...
  "Package::unpackNext()", referenced from:
      Package::startUnpackZipsFull() in package.cc.o
      Package::startUnpackZips() in package.cc.o
      Package::createPsvImgs(QString)::$_10::operator()(void*) const in package.cc.o
  "Package::unpackedZip(QString)", referenced from:
      Package::doUnpackZip()::$_5::operator()(void*) const in package.cc.o
  "Package::unpackedDemo()", referenced from:
      Package::startUnpackDemo(char const*)::$_3::operator()(void*) const in package.cc.o
  "Package::noHencoreFull()", referenced from:
      Package::checkHencoreFull()::$_8::operator()(void*) const in package.cc.o
  "Package::setStatusText(QString)", referenced from:
      Package::tips() in package.cc.o
      Package::startDownload(QString const&, QString const&) in package.cc.o
      Package::verify(QString const&, char const*) in package.cc.o
      Package::finishBuildData() in package.cc.o
      Package::startUnpackDemo(char const*)::$_2::operator()(void*) const in package.cc.o
      Package::doUnpackZip()::$_4::operator()(void*) const in package.cc.o
      Package::createPsvImgs(QString)::$_9::operator()(void*) const in package.cc.o
      ...
  "Package::startDownload()", referenced from:
      FinalHE::onStart() in finalhe.cc.o
  "Package::createdPsvImgs()", referenced from:
      Package::createPsvImgs(QString)::$_10::operator()(void*) const in package.cc.o
  "Package::staticMetaObject", referenced from:
      Package::tr(char const*, char const*, int) in package.cc.o
  "VitaConn::receivedPin(QString, int)", referenced from:
      generatePin(wireless_vita_info*, int*) in vita.cc.o
  "VitaConn::completedPin()", referenced from:
      registrationComplete() in vita.cc.o
  "VitaConn::gotAccountId(QString)", referenced from:
      FinalHE::FinalHE(QWidget*) in finalhe.cc.o
      VitaConn::processEvent(LIBVitaMTP_event*) in vita.cc.o
  "VitaConn::setStatusText(QString)", referenced from:
      VitaConn::updateStatus() in vita.cc.o
  "VitaConn::staticMetaObject", referenced from:
      std::__1::enable_if<(QtPrivate::FunctionPointer<FinalHE::FinalHE(QWidget*)::$_0>::ArgumentCount) == (-(1)), QMetaObject::Connection>::type QObject::connect<void (VitaConn::*)(QString), FinalHE::FinalHE(QWidget*)::$_0>(QtPrivate::FunctionPointer<void (VitaConn::*)(QString)>::Object const*, void (VitaConn::*)(QString), QObject const*, FinalHE::FinalHE(QWidget*)::$_0, Qt::ConnectionType) in finalhe.cc.o
      VitaConn::tr(char const*, char const*, int) in vita.cc.o
  "VitaConn::builtData()", referenced from:
      VitaConn::buildData() in vita.cc.o
  "vtable for Downloader", referenced from:
      Downloader::Downloader(QObject*) in downloader.cc.o
      Downloader::~Downloader() in package.cc.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for Worker", referenced from:
      Worker::Worker(void*, QObject*) in worker.cc.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for FinalHE", referenced from:
      FinalHE::FinalHE(QWidget*) in finalhe.cc.o
      FinalHE::~FinalHE() in finalhe.cc.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for Package", referenced from:
      Package::Package(QString const&, QString const&, QObject*) in package.cc.o
      Package::~Package() in package.cc.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for VitaConn", referenced from:
      VitaConn::VitaConn(QString const&, QString const&, QObject*) in vita.cc.o
      VitaConn::~VitaConn() in vita.cc.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/FinalHE] Error 1
make[1]: *** [src/CMakeFiles/FinalHE.dir/all] Error 2
make: *** [all] Error 2
```  
  
To correct this we need to set the cmake policy if the user is running cmake version 3.17 or above by adding the following lines to the `CMakeLists.txt` file:  
```
if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
    cmake_policy(SET CMP0100 NEW)
endif()
```  
After adding the above `cmake .` will run successfully:  
```
tylerww@MacBookPro finalhe % cmake .
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/tylerww/Desktop/finalhe
tylerww@MacBookPro finalhe % 
```