### PR TITLE
Use current path instead of application path for extras

### DIFF
--- a/src/finalhe.cc
+++ b/src/finalhe.cc
@@ -42,7 +42,7 @@ FinalHE::FinalHE(QWidget *parent): QMainWindow(parent) {
     ui.textMTP->setStyleSheet("QLabel { color : blue; }");
 
     ui.progressBar->setMaximum(100);
-    QDir baseDir, dir(qApp->applicationDirPath());
+    QDir baseDir, dir(QDir::currentPath());
 #ifdef __APPLE__
     dir.cdUp(); dir.cdUp(); dir.cdUp();
 #endif


### PR DESCRIPTION
When installing FinalHE with archlinux, the binary is put into /usr/bin/. You can't really put zip files there (or at least you shouldn't). This change uses the directory from where finalhe was called instead of the application location.

Maybe, someone needs to check, if this change affects the windows version, as I can't test there.